### PR TITLE
enables terraform version policy

### DIFF
--- a/allowed-terraform-version.sentinel .hcl
+++ b/allowed-terraform-version.sentinel .hcl
@@ -1,0 +1,8 @@
+#enables terraform version policy
+#check terraform policy docs for further reads 
+
+import "tfplan"
+
+main = rule {
+  tfplan.terraform_version matches "^0\\.12\\.\\d+$"
+}


### PR DESCRIPTION
The policy will pass and return a value of true when the Terraform version is 0.12.0 and above.